### PR TITLE
Prevent filters from exeeding height of page

### DIFF
--- a/wpadmin/static/wpadmin/css/wpadmin.css
+++ b/wpadmin/static/wpadmin/css/wpadmin.css
@@ -1246,7 +1246,9 @@ body.change-list #content h1 {
     margin: 0;
     padding: 6px 10px;
     list-style-type: none;
-    top: -4px
+    top: -4px;
+    overflow-y: auto;
+    max-height: 20em
 }
 
 #content #changelist #changelist-filter .filter ul li {


### PR DESCRIPTION
Currently, the filter for problem authors on prod exceeds the length of the page.

This PR limits it to the current view height, and handles overflow with a scrollbar, if needed.