### PR TITLE
Fix martor dropdown in secondary editors

### DIFF
--- a/wpadmin/static/wpadmin/css/wpadmin.css
+++ b/wpadmin/static/wpadmin/css/wpadmin.css
@@ -1826,6 +1826,10 @@ body.change-form #content-main {
     overflow-y: hidden
 }
 
+#content .inline-group .tabular.tab-martor-menu {
+    overflow-y: inherit
+}
+
 #content .inline-group .tabular tr.has_original td {
     padding-top: 2.2em
 }


### PR DESCRIPTION
fixes https://github.com/DMOJ/online-judge/issues/2020

`overflow-y: hidden` can't be deleted. it's used in `/admin/judge/contest/1/change/` Problems table on a narrow screen