### PR TITLE
Clean up deprecated usage of ugettext_lazy and ifequal

### DIFF
--- a/wpadmin/menu/items.py
+++ b/wpadmin/menu/items.py
@@ -1,7 +1,7 @@
 import re
 
 from django.utils.text import capfirst
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wpadmin.menu.utils import UserTestElementMixin, AppListElementMixin
 

--- a/wpadmin/menu/menus.py
+++ b/wpadmin/menu/menus.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 from django.urls import reverse
 

--- a/wpadmin/templates/admin/pagination.html
+++ b/wpadmin/templates/admin/pagination.html
@@ -6,6 +6,6 @@
     {% paginator_number cl i %}
 {% endfor %}
 {% endif %}
-<span class="total">{{ cl.result_count }} {% ifequal cl.result_count 1 %}{{ cl.opts.verbose_name }}{% else %}{{ cl.opts.verbose_name_plural }}{% endifequal %}</span>
+<span class="total">{{ cl.result_count }} {% if cl.result_count == 1 %}{{ cl.opts.verbose_name }}{% else %}{{ cl.opts.verbose_name_plural }}{% endif %}</span>
 {% if show_all_url %}&nbsp;&nbsp;<a href="{{ show_all_url }}" class="showall">{% trans 'Show all' %}</a>{% endif %}
 </p>

--- a/wpadmin/templatetags/wpadmin_tags.py
+++ b/wpadmin/templatetags/wpadmin_tags.py
@@ -1,6 +1,6 @@
 from django import template
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wpadmin.utils import (
     get_admin_site_name, get_wpadmin_settings, are_breadcrumbs_enabled)


### PR DESCRIPTION
Clean up `ugettext_lazy` and `ifequal`, which have long been deprecated.
Related to DMOJ/online-judge#2322.